### PR TITLE
Added global variables OnetrustActiveGroups and OptanonActiveGroups as consent information source

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,7 +1,7 @@
 homepage: "https://tanelytics.com/"
 documentation: "https://github.com/taneli-salonen1/gtm-onetrust-consent-groups"
 versions:
-  - sha: 4e78a32b3ed74ecde0d7d66d5e742d43ef3afc35
+  - sha: 4804c2880e9c8bd26ddd3c2b34e3d6f3b8db7e36
     changeNotes: Added global variables OnetrustActiveGroups and OptanonActiveGroups as consent information source.
   - sha: 69ae56de8abb14bb386d87610768cf47d59648c9
     changeNotes: Added option to return individual consent statuses in consent mode format, granted or denied.

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,6 +1,8 @@
 homepage: "https://tanelytics.com/"
 documentation: "https://github.com/taneli-salonen1/gtm-onetrust-consent-groups"
 versions:
+  - sha: 4e78a32b3ed74ecde0d7d66d5e742d43ef3afc35
+    changeNotes: Added global variables OnetrustActiveGroups and OptanonActiveGroups as consent information source.
   - sha: 69ae56de8abb14bb386d87610768cf47d59648c9
     changeNotes: Added option to return individual consent statuses in consent mode format, granted or denied.
   - sha: 2673adcae56844d304163304aebaaf74f78bd51e

--- a/readme.md
+++ b/readme.md
@@ -3,9 +3,10 @@
 This Google Tag Manager template returns the consent group values that the visitor has opted in to.
 
 Functionality:
-1. If the consent groups are already available in the dataLayer, return the values from there.
-2. If the dataLayer message has not yet been pushed by OneTrust, read the OptanonConsent cookie and return the consent groups from there.
-3. If neither the dataLayer nor the cookie is available (visitor first visit when OneTrust hasn't yet loaded), return a possible fallback default value that has been entered in the template. Otherwise return an empty value.
+1. If the consent groups are already available in the global variables, return the values from there.
+2. If the consent groups are already available in the dataLayer, return the values from there.
+3. If the dataLayer message has not yet been pushed by OneTrust, read the OptanonConsent cookie and return the consent groups from there.
+4. If neither the dataLayer nor the cookie is available (visitor first visit when OneTrust hasn't yet loaded), return a possible fallback default value that has been entered in the template. Otherwise return an empty value.
 
 Output options:
 A comma joined string or a JS array.


### PR DESCRIPTION
Hi!

Using the official OneTrust CMP Template I've noticed that it calls `gtag('consent', 'update', ...)` in right before the `OneTrustLoaded` event (this is the first one, that's followed by `OptanonLoaded` and `OneTrustGroupsUpdated`).

In the original version of this variable template this line reads the current consent from the data layer variables:
```js
const consentDataLayer = copyFromDataLayer('OptanonActiveGroups') || copyFromDataLayer('OnetrustActiveGroups');

```
But, depending on the data layer event that this template variable was evaluated, there could be a mismatch of one data layer variable to the other.
In this particular event below the data layer variable `OptanonActiveGroups` hasn't been updated yet (but the `OnetrustActiveGroups` has), thus the template was getting outdated consent information.
```
{
	event: "OneTrustLoaded",
	OnetrustActiveGroups: ",C0001,C0002,C0003,C0004,",
}
```

I noticed that there are two global variables `OptanonActiveGroups` and `OnetrustActiveGroups` which are updated by OneTrust SDK right before it fires the data layer events. Therefore, they have the most updated consent information.

So, to fix that mismatch I added these two global variables to the template. It will read them before attempting to read the data layer variables. 

Cheers!